### PR TITLE
Use release drafter v7

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,4 +1,4 @@
 # https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc
 
-_extends: .github
+_extends: github:jenkinsci/.github:/.github/release-drafter.yml
 tag-template: javax-activation-api-$NEXT_MINOR_VERSION

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,6 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## User release drafter v7

Explicitly load release drafter base config from GitHub

Release drafter v7 no longer accepts .github as a valid extension.

The [release drafter documentation](https://github.com/release-drafter/release-drafter/blob/master/docs/configuration-loading.md#fetching-from-a-repo-named-github) says:

> The github: prefix is used internally to recognize you want to explicitly fetch from a remote (using octokit) instead of loading a file on the runtime's filesystem.

### Testing done

Tested in many repositories.  Will verify these repositories after merge.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
